### PR TITLE
Remove tags from the eCard template interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,7 +125,6 @@ export interface IEcardTemplate extends IPodiumModel {
     program_id: number
     subject: string
     message: string
-    tags: [string]
     image: IImage
     categories: [IEcardCategory]
 }


### PR DESCRIPTION
Tags are being removed from the eCard template interface as they are no longer supported by the Podium API.